### PR TITLE
Fix build for FastAPI evaluation image

### DIFF
--- a/evaluation/Adb.dockerfile
+++ b/evaluation/Adb.dockerfile
@@ -3,7 +3,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
 RUN apt-get update -yqq && apt-get install -yqq python3-tqdm gnat-12
+RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
 
 COPY src /code
 WORKDIR /code
-ENTRYPOINT ["python3", "main.py"]
+ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090"]

--- a/evaluation/Makefile
+++ b/evaluation/Makefile
@@ -1,14 +1,16 @@
 DOCKER_EXEC=podman
 
 build: Dockerfile Adb.dockerfile
-	${DOCKER_EXEC} build -t multipl-e-evaluation .
-	${DOCKER_EXEC} build -t ghcr.io/nuprl/multipl-e:adb -f Adb.dockerfile
+        ${DOCKER_EXEC} build -t multipl-e-evaluation .
+        ${DOCKER_EXEC} build -t ghcr.io/nuprl/multipl-e:adb -f Adb.dockerfile
 
 test: build
-	${DOCKER_EXEC} run --rm \
-		--network none \
-		--volume $(PWD)/test_inputs:/inputs:ro \
-		--volume $(PWD)/test_outputs:/outputs:rw \
-		multipl-e-evaluation --dir /inputs --output-dir /outputs --testing
+        ${DOCKER_EXEC} run --rm \
+                --network none \
+                --volume $(PWD)/test_inputs:/inputs:ro \
+                --volume $(PWD)/test_outputs:/outputs:rw \
+                --entrypoint python3 \
+                multipl-e-evaluation \
+                main.py --dir /inputs --output-dir /outputs --testing
 
 all: build test


### PR DESCRIPTION
## Summary
- ensure `evaluation/Makefile` calls `main.py` despite the new FastAPI entrypoint
- run the Ada image as a FastAPI server like the main evaluation image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6852868178ec83318c4e022ecc4f7f0c