### PR TITLE
Add python3-pip to Adb Dockerfile

### DIFF
--- a/evaluation/Adb.dockerfile
+++ b/evaluation/Adb.dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-RUN apt-get update -yqq && apt-get install -yqq python3-tqdm gnat-12
+RUN apt-get update -yqq && \
+    apt-get install -yqq python3-pip python3-tqdm gnat-12
 RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
 
 COPY src /code


### PR DESCRIPTION
## Summary
- include python3-pip in `apt-get install` for Adb container

## Testing
- `make test` *(fails: Makefile:4: *** missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_6852b37d51208331b2a309f93459c5d0