### PR TITLE
Switch evaluation_singularity to singularity

### DIFF
--- a/evaluation_singularity/Adb.dockerfile
+++ b/evaluation_singularity/Adb.dockerfile
@@ -1,11 +1,20 @@
-FROM ubuntu:22.04
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=Etc/UTC
+Bootstrap: docker
+From: ubuntu:22.04
 
-RUN apt-get update -yqq && \
-    apt-get install -yqq python3-pip python3-tqdm gnat-12
-RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
+%environment
+    export DEBIAN_FRONTEND=noninteractive
+    export TZ=Etc/UTC
 
-COPY src /code
-WORKDIR /code
-ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090"]
+%post
+    apt-get update -yqq && \
+        apt-get install -yqq python3-pip python3-tqdm gnat-12
+    python3 -m pip install numpy fastapi "uvicorn[standard]"
+    mkdir -p /code
+
+%files
+    src /code
+
+%workdir /code
+
+%runscript
+    exec uvicorn api:app --host 0.0.0.0 --port 9090

--- a/evaluation_singularity/Dockerfile
+++ b/evaluation_singularity/Dockerfile
@@ -1,114 +1,103 @@
-FROM ubuntu:22.04
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=Etc/UTC
-RUN apt-get update -yqq && apt-get install -yqq \
-    curl racket build-essential python3-pip python3-tqdm \
-    default-jdk-headless \
-    golang-go \
-    php-cli \
-    ruby \
-    lua5.3 \
-    r-base \
-    rustc \
-    scala \
-    ocaml-interp \
-    ocaml \
-    ghc \
-    libtest-deep-perl \
-    wget \
-    lua-unit \
-    aspnetcore-runtime-6.0
+Bootstrap: docker
+From: ubuntu:22.04
 
-RUN apt-get install -yqq libtest-deep-perl
-RUN apt-get install -yqq wget
+%environment
+    export DEBIAN_FRONTEND=noninteractive
+    export TZ=Etc/UTC
+    export PATH="/julia-1.8.2/bin:/swift-5.7-RELEASE-ubuntu22.04/usr/bin:/erlang/bin:/elixir/bin:/clojure/bin:$PATH"
+    export LANG=C.UTF-8
 
-# JS/TS
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g typescript
+%post
+    apt-get update -yqq && apt-get install -yqq \
+        curl racket build-essential python3-pip python3-tqdm \
+        default-jdk-headless \
+        golang-go \
+        php-cli \
+        ruby \
+        lua5.3 \
+        r-base \
+        rustc \
+        scala \
+        ocaml-interp \
+        ocaml \
+        ghc \
+        libtest-deep-perl \
+        wget \
+        lua-unit \
+        aspnetcore-runtime-6.0
 
-# Dlang
-RUN wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EDC4FB09C3AEEDD0
-RUN apt-get update
-RUN apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
-RUN apt-get update && apt-get install -yqq dmd-compiler dub
+    apt-get install -yqq libtest-deep-perl
+    apt-get install -yqq wget
 
-# C#
-RUN apt install gnupg ca-certificates
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
-RUN apt update --allow-insecure-repositories
-RUN apt install -yqq mono-devel
+    # JS/TS
+    curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+    apt-get install -y nodejs
+    npm install -g typescript
 
-# F#
-# RUN apt-get install -y dotnet6
+    # Dlang
+    wget https://netcologne.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EDC4FB09C3AEEDD0
+    apt-get update
+    apt-get -y --allow-unauthenticated install --reinstall d-apt-keyring
+    apt-get update && apt-get install -yqq dmd-compiler dub
 
-# Post-processing
+    # C#
+    apt install -y gnupg ca-certificates
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+    apt update --allow-insecure-repositories
+    apt install -yqq mono-devel
 
-# Julia
-RUN curl https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz | tar xz
-ENV PATH="/julia-1.8.2/bin:${PATH}"
-# Swift
-RUN curl https://download.swift.org/swift-5.7-release/ubuntu2204/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu22.04.tar.gz | tar xz
-ENV PATH="/swift-5.7-RELEASE-ubuntu22.04/usr/bin:${PATH}"
-# Javatuples
-RUN mkdir /usr/multiple && wget https://repo.mavenlibs.com/maven/org/javatuples/javatuples/1.2/javatuples-1.2.jar -O /usr/multiple/javatuples-1.2.jar
+    # Julia
+    curl https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz | tar xz
 
-# Luau
-RUN wget https://github.com/Roblox/luau/releases/download/0.594/luau-ubuntu.zip -O /tmp/luau.zip && unzip /tmp/luau.zip -d /bin/
+    # Swift
+    curl https://download.swift.org/swift-5.7-release/ubuntu2204/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu22.04.tar.gz | tar xz
 
-# Elixir
-# Install Erlang
-RUN mkdir -p /erlang && \
-    cd /erlang && \
-    wget -nv -O erlang.tar.gz https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.0.tar.gz && \
-    tar xzf erlang.tar.gz --strip-components=1 && \
-    ./Install -minimal "$(pwd)"
+    # Javatuples
+    mkdir /usr/multiple && wget https://repo.mavenlibs.com/maven/org/javatuples/javatuples/1.2/javatuples-1.2.jar -O /usr/multiple/javatuples-1.2.jar
 
-# Erlang runtime dependencies, see https://github.com/hexpm/bob/blob/4fe43eb9853bb95dbfe276957bd7d3f931a451b3/priv/scripts/docker/erlang-ubuntu-jammy.dockerfile
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install \
-    ca-certificates \
-    libodbc1 \
-    libssl3 \
-    libsctp1
+    # Luau
+    wget https://github.com/Roblox/luau/releases/download/0.594/luau-ubuntu.zip -O /tmp/luau.zip && unzip /tmp/luau.zip -d /bin/
 
-# Install Elixir
-RUN mkdir -p /elixir && \
-    cd /elixir && \
-    wget -nv -O elixir.zip https://builds.hex.pm/builds/elixir/v1.17.2-otp-27.zip && \
-    unzip -q elixir.zip
+    # Elixir
+    mkdir -p /erlang && \
+        cd /erlang && \
+        wget -nv -O erlang.tar.gz https://builds.hex.pm/builds/otp/ubuntu-22.04/OTP-27.0.tar.gz && \
+        tar xzf erlang.tar.gz --strip-components=1 && \
+        ./Install -minimal "$(pwd)"
 
-ENV PATH="/erlang/bin:/elixir/bin:${PATH}"
-ENV LANG=C.UTF-8
+    apt-get update && \
+        apt-get -y --no-install-recommends install \
+        ca-certificates \
+        libodbc1 \
+        libssl3 \
+        libsctp1
 
-# Dafny
-# https://github.com/dafny-lang/dafny/releases/download/v4.3.0/dafny-4.3.0-x64-ubuntu-20.04.zip
-# RUN mkdir -p /root/dafny
-# RUN wget https://github.com/dafny-lang/dafny/releases/download/v4.3.0/dafny-4.3.0-x64-ubuntu-20.04.zip -O /tmp/dafny.zip && unzip /tmp/dafny.zip -d /root/dafny/ && ln -s /root/dafny/dafny/dafny /bin/dafny
+    mkdir -p /elixir && \
+        cd /elixir && \
+        wget -nv -O elixir.zip https://builds.hex.pm/builds/elixir/v1.17.2-otp-27.zip && \
+        unzip -q elixir.zip
 
-# Clojure - https://clojure.org/guides/install_clojure#_linux_instructions
-RUN curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh
-RUN chmod +x linux-install.sh
-RUN ./linux-install.sh --prefix /clojure
-ENV PATH="/clojure/bin:${PATH}"
-RUN clojure -P
+    # Clojure
+    curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh
+    chmod +x linux-install.sh
+    ./linux-install.sh --prefix /clojure
+    clojure -P
 
-# Dart
-RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg  --dearmor -o /usr/share/keyrings/dart.gpg
-RUN echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
-RUN apt-get update -yqq && apt-get install -yqq dart
+    # Dart
+    wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg
+    echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list
+    apt-get update -yqq && apt-get install -yqq dart
 
-# Coq
-# RUN apt-get install -yqq coq
+    python3 -m pip install numpy fastapi "uvicorn[standard]"
 
-# Lean
-# RUN wget https://github.com/leanprover/lean4/releases/download/v4.6.0-rc1/lean-4.6.0-rc1-linux.zip -O /tmp/lean.zip && unzip /tmp/lean.zip -d /root/lean/ && ln -s /root/lean/bin/lean /bin/lean
+    mkdir -p /code
 
-# install numpy for humanevalplus
-RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
+%files
+    src /code
 
-COPY src /code
-WORKDIR /code
-ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090"]
+%workdir /code
+
+%runscript
+    exec uvicorn api:app --host 0.0.0.0 --port 9090

--- a/evaluation_singularity/Makefile
+++ b/evaluation_singularity/Makefile
@@ -1,16 +1,15 @@
-DOCKER_EXEC=podman
+SINGULARITY_EXEC?=singularity
 
 build: Dockerfile Adb.dockerfile
-	${DOCKER_EXEC} build -t multipl-e-evaluation .
-	${DOCKER_EXEC} build -t ghcr.io/nuprl/multipl-e:adb -f Adb.dockerfile
+	${SINGULARITY_EXEC} build multipl-e-evaluation.sif Dockerfile
+	${SINGULARITY_EXEC} build multipl-e-adb.sif Adb.dockerfile
 
 test: build
-	${DOCKER_EXEC} run --rm \
-		--network none \
-		--volume $(PWD)/test_inputs:/inputs:ro \
-		--volume $(PWD)/test_outputs:/outputs:rw \
-		--entrypoint python3 \
-		multipl-e-evaluation \
-		main.py --dir /inputs --output-dir /outputs --testing
+	${SINGULARITY_EXEC} exec \
+	--network none \
+	--bind $(PWD)/test_inputs:/inputs:ro \
+	--bind $(PWD)/test_outputs:/outputs:rw \
+	multipl-e-evaluation.sif \
+		python3 main.py --dir /inputs --output-dir /outputs --testing
 
 all: build test

--- a/evaluation_singularity/README.md
+++ b/evaluation_singularity/README.md
@@ -12,7 +12,7 @@ This directory contains code to evaluate all languages supported by MultiPL-E.
 
 ## Usage
 
-The `build` command builds the container:
+The `build` command builds the container using Singularity:
 
 ```bash
 make build
@@ -22,27 +22,18 @@ To run the container, place all of the completion files under a directory, then 
 Use the `--volume` option to create directory mappings.
 
 ```bash
-	docker run --rm --network none 
-		--volume ${PWD}/inputs:/inputs:ro \
-		--volume ${PWD}/outputs:/outputs:rw \
-		multipl-e-evaluation \
-                --dir $INPUT_DIR \
-                --output-dir $OUTPUT_DIR
+singularity exec \
+    --network none \
+    --bind ${PWD}/inputs:/inputs:ro \
+    --bind ${PWD}/outputs:/outputs:rw \
+    multipl-e-evaluation.sif \
+    python3 main.py --dir $INPUT_DIR --output-dir $OUTPUT_DIR
 ```
 
 The `$INPUT_DIR` argument should be a directory with completions. See the `test_inputs` for an example.
 The `$OUTPUT_DIR` argument is the directory where results are generated.
 
 
-## Specifying alternate docker instance
-
-The docker (or podman) instance can be specified:
-
-```bash
-make DOCKER_EXEC="docker" test
-```
-
-(We use Podman by default.)
 
 ## Testing mode
 


### PR DESCRIPTION
## Summary
- build evaluation_singularity container images with Singularity instead of Podman
- convert container specs to Singularity definition format
- update README with new usage instructions

## Testing
- `python3 -m compileall -q evaluation_singularity/src`
- `singularity --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fd35edf48331ad7c3a5e49f84b13