### PR TITLE
Enhance evaluation API concurrency

### DIFF
--- a/evaluation/Dockerfile
+++ b/evaluation/Dockerfile
@@ -111,4 +111,4 @@ RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
 
 COPY src /code
 WORKDIR /code
-ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090"]
+ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090", "--workers", "4", "--limit-concurrency", "100"]

--- a/evaluation/src/api.py
+++ b/evaluation/src/api.py
@@ -16,12 +16,17 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import time
 from containerized_eval import eval_string_script
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 class EvalRequest(BaseModel):
     language: str
     prompt: str
     completion: str
     tests: str
+
+executor = ThreadPoolExecutor(max_workers=100)
+semaphore = asyncio.Semaphore(100)
 
 app = FastAPI()
 
@@ -41,10 +46,31 @@ async def evaluate(req: EvalRequest):
         ``stderr``, ``exit_code``, ``status`` and ``timestamp``.
     """
     program = req.prompt + req.completion + "\n" + req.tests
-    result = eval_string_script(req.language, program)
+    loop = asyncio.get_running_loop()
+    try:
+        async with semaphore:
+            result = await asyncio.wait_for(
+                loop.run_in_executor(executor, eval_string_script, req.language, program),
+                timeout=30,
+            )
+    except asyncio.TimeoutError:
+        return {
+            "program": program,
+            "stdout": "",
+            "stderr": "Timeout",
+            "exit_code": -1,
+            "status": "Timeout",
+            "timestamp": int(time.time()),
+        }
     result["timestamp"] = int(time.time())
     return result
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("api:app", host="0.0.0.0", port=9090)
+    uvicorn.run(
+        "api:app",
+        host="0.0.0.0",
+        port=9090,
+        workers=4,
+        limit_concurrency=100,
+    )

--- a/evaluation_arm64/Dockerfile
+++ b/evaluation_arm64/Dockerfile
@@ -110,4 +110,4 @@ RUN python3 -m pip install numpy fastapi "uvicorn[standard]"
 
 COPY src /code
 WORKDIR /code
-ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090"]
+ENTRYPOINT ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "9090", "--workers", "4", "--limit-concurrency", "100"]

--- a/evaluation_arm64/src/api.py
+++ b/evaluation_arm64/src/api.py
@@ -16,12 +16,17 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import time
 from containerized_eval import eval_string_script
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 class EvalRequest(BaseModel):
     language: str
     prompt: str
     completion: str
     tests: str
+
+executor = ThreadPoolExecutor(max_workers=100)
+semaphore = asyncio.Semaphore(100)
 
 app = FastAPI()
 
@@ -41,10 +46,31 @@ async def evaluate(req: EvalRequest):
         ``stderr``, ``exit_code``, ``status`` and ``timestamp``.
     """
     program = req.prompt + req.completion + "\n" + req.tests
-    result = eval_string_script(req.language, program)
+    loop = asyncio.get_running_loop()
+    try:
+        async with semaphore:
+            result = await asyncio.wait_for(
+                loop.run_in_executor(executor, eval_string_script, req.language, program),
+                timeout=30,
+            )
+    except asyncio.TimeoutError:
+        return {
+            "program": program,
+            "stdout": "",
+            "stderr": "Timeout",
+            "exit_code": -1,
+            "status": "Timeout",
+            "timestamp": int(time.time()),
+        }
     result["timestamp"] = int(time.time())
     return result
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("api:app", host="0.0.0.0", port=9090)
+    uvicorn.run(
+        "api:app",
+        host="0.0.0.0",
+        port=9090,
+        workers=4,
+        limit_concurrency=100,
+    )


### PR DESCRIPTION
## Summary
- allow concurrent requests to evaluation API
- limit concurrency with a semaphore and ThreadPoolExecutor
- add 30s timeout handling
- run uvicorn with multiple workers in container
- mirror changes for arm64 build

## Testing
- `python3 -m py_compile evaluation/src/api.py`
- `python3 -m py_compile evaluation_arm64/src/api.py`
- `make -C evaluation test` *(fails: `podman` not found)*
- `make -C evaluation_arm64 test` *(fails: `podman` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baa69485c8331978d4aadcc135826