### PR TITLE
Align API with evaluation JSON format

### DIFF
--- a/evaluation/src/api.py
+++ b/evaluation/src/api.py
@@ -1,15 +1,21 @@
-"""Minimal FastAPI server for evaluating a single completion.
+"""Minimal FastAPI server for evaluating completions.
 
-This API exposes one POST endpoint `/evaluate` which accepts a JSON body
-describing the program to execute.  The input fields are:
+This API exposes one POST endpoint ``/evaluate`` which accepts a JSON
+payload describing the completions to execute.  The expected schema is the
+same as the files consumed by :mod:`evaluation.src.main`, namely::
 
-* ``language``  - name of the programming language (e.g. ``"python"``)
-* ``prompt``    - preamble string containing helper code
-* ``completion``- the completion to evaluate
-* ``tests``     - test code appended after the completion
+    {
+        "name": "HumanEval_53_add",           # optional
+        "language": "python",
+        "prompt": "...",
+        "tests": "...",
+        "completions": ["completion1", "completion2"],
+        "stop_tokens": ["\n"]
+    }
 
-The response is a JSON object containing the execution result with keys like
-``stdout`` and ``stderr`` along with a ``timestamp`` field.
+The response mirrors the structure produced by ``evaluation.src.main`` where
+``completions`` is replaced with ``results`` containing execution metadata for
+each completion.
 """
 
 from fastapi import FastAPI
@@ -20,10 +26,17 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 class EvalRequest(BaseModel):
+    """Request model matching ``evaluation.src.main`` input files."""
+
     language: str
     prompt: str
-    completion: str
     tests: str
+    completions: list[str]
+    name: str | None = None
+    stop_tokens: list[str] | None = None
+
+    class Config:
+        extra = "allow"
 
 executor = ThreadPoolExecutor(max_workers=100)
 semaphore = asyncio.Semaphore(100)
@@ -32,12 +45,13 @@ app = FastAPI()
 
 @app.post("/evaluate")
 async def evaluate(req: EvalRequest):
-    """Execute the provided program and return the result.
+    """Execute the provided completions and return the results.
 
     Parameters
     ----------
     req: EvalRequest
-        JSON payload with ``language``, ``prompt``, ``completion`` and ``tests``.
+        JSON payload describing a set of completions in the same format as used
+        by :mod:`evaluation.src.main`.
 
     Returns
     -------
@@ -45,25 +59,31 @@ async def evaluate(req: EvalRequest):
         JSON object with execution metadata including ``stdout``,
         ``stderr``, ``exit_code``, ``status`` and ``timestamp``.
     """
-    program = req.prompt + req.completion + "\n" + req.tests
     loop = asyncio.get_running_loop()
-    try:
-        async with semaphore:
-            result = await asyncio.wait_for(
-                loop.run_in_executor(executor, eval_string_script, req.language, program),
-                timeout=30,
-            )
-    except asyncio.TimeoutError:
-        return {
-            "program": program,
-            "stdout": "",
-            "stderr": "Timeout",
-            "exit_code": -1,
-            "status": "Timeout",
-            "timestamp": int(time.time()),
-        }
-    result["timestamp"] = int(time.time())
-    return result
+    results = []
+    for completion in req.completions:
+        program = req.prompt + completion + "\n" + req.tests
+        try:
+            async with semaphore:
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(executor, eval_string_script, req.language, program),
+                    timeout=30,
+                )
+        except asyncio.TimeoutError:
+            result = {
+                "program": program,
+                "stdout": "",
+                "stderr": "Timeout",
+                "exit_code": -1,
+                "status": "Timeout",
+            }
+        result["timestamp"] = int(time.time())
+        results.append(result)
+
+    response = req.dict()
+    response.pop("completions", None)
+    response["results"] = results
+    return response
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- update FastAPI server to accept same JSON format as evaluation.main
- evaluate multiple completions per request and mirror evaluation.main output

## Testing
- `python3 -m py_compile evaluation/src/api.py`

------
https://chatgpt.com/codex/tasks/task_e_686c83791fbc8331b7b4680435487c93