### PR TITLE
Limit CPU cores and parallelism during go test, and add timeout for r…

### DIFF
--- a/evaluation/src/eval_go.py
+++ b/evaluation/src/eval_go.py
@@ -11,8 +11,8 @@ def eval_script(path: Path):
     stderr = None
     exit_code = None
     try:
-        build = subprocess.run(["go", "test", path],
-                               timeout=30,
+        build = subprocess.run(["env", "GOMAXPROCS=1", "go", "test", "-p", "1", "-timeout=30s", path],
+                               timeout=60,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
 


### PR DESCRIPTION
go test実行時にgoroutineの生成数や並行処理数の制限を行い，ホストマシンのリソース確保と安定化を行う．