### PR TITLE
fix elixir test timeout problem

### DIFF
--- a/evaluation/src/eval_elixir.py
+++ b/evaluation/src/eval_elixir.py
@@ -8,7 +8,7 @@ from generic_eval import main as gmain
 def eval_script(path: Path):
     try:
         # Assumes exit-code 0 is all okay
-        output = subprocess.run(["elixir", str(path)], capture_output=True, timeout=5)
+        output = subprocess.run(["elixir", str(path)], capture_output=True, timeout=30, stdin=subprocess.DEVNULL)
 
         if output.returncode == 0:
             status = "OK"


### PR DESCRIPTION
Elixirのtest時の結果がすべてtimeoutになる問題の修正．また，timeoutを5secから30secに変更した．