### PR TITLE
Added functionality to verify whether the MultiPL-E server is alive

### DIFF
--- a/completion_eval_analysis/lang2url.json
+++ b/completion_eval_analysis/lang2url.json
@@ -5,20 +5,26 @@
         "dart": "https://rkbque6gsc7xou4i2zenn2lpdy0bfxbw.lambda-url.ap-northeast-1.on.aws/",
         "clj": "https://qcn3wjq32gurg5fqg3y4kfxlwq0hsrju.lambda-url.ap-northeast-1.on.aws/",
         "ada": "https://ucn6uvhy25reuu2dfzs6ymy3yi0hhutt.lambda-url.ap-northeast-1.on.aws/",
+        "adb": "https://ucn6uvhy25reuu2dfzs6ymy3yi0hhutt.lambda-url.ap-northeast-1.on.aws/",
         "julia": "https://m4kdcclfwjuics7gcjgqzudx5i0hbiht.lambda-url.ap-northeast-1.on.aws/",
+        "jl": "https://m4kdcclfwjuics7gcjgqzudx5i0hbiht.lambda-url.ap-northeast-1.on.aws/",
         "fs": "https://lmxa5wl4trvegfo7uv4nt4uiie0iychc.lambda-url.ap-northeast-1.on.aws/",
         "dfy": "https://qrstug5gprp6kswt6pmplay6na0lfucg.lambda-url.ap-northeast-1.on.aws/",
         "scala": "https://sg7txllm6eyfz34dc33tjrqlny0lbfqw.lambda-url.ap-northeast-1.on.aws/",
         "ruby": "https://3fntmk2hlhmkf4rtzlg67f55ka0scmne.lambda-url.ap-northeast-1.on.aws/",
+        "rb": "https://3fntmk2hlhmkf4rtzlg67f55ka0scmne.lambda-url.ap-northeast-1.on.aws/",
         "v": "https://iqupjmfvoyam5tzm7bibovwkk40bfpak.lambda-url.ap-northeast-1.on.aws/",
         "sh": "https://rruvoapzd4skea7hu2fficp5zq0iklyj.lambda-url.ap-northeast-1.on.aws/",
         "r": "https://ojg6aa252tantcc5l7aa3dxejm0ypmhl.lambda-url.ap-northeast-1.on.aws/",
         "cpp": "https://uronydcduufrlhkgzmrjnxnnji0njnmk.lambda-url.ap-northeast-1.on.aws/",
         "racket": "https://74z7jf34y4huzggzrsp3iwz77y0wmzao.lambda-url.ap-northeast-1.on.aws/",
+        "rkt": "https://74z7jf34y4huzggzrsp3iwz77y0wmzao.lambda-url.ap-northeast-1.on.aws/",
         "pl": "https://axmdnn5try54i6qook5hyf3y7e0qseor.lambda-url.ap-northeast-1.on.aws/",
         "python": "https://6onkqaeyox367zryq2zkd5age40hqgfq.lambda-url.ap-northeast-1.on.aws/",
         "ocaml": "https://ehvfz4ifmzh3i5fuz2ljt3agnm0utwqp.lambda-url.ap-northeast-1.on.aws/",
+        "ml": "https://ehvfz4ifmzh3i5fuz2ljt3agnm0utwqp.lambda-url.ap-northeast-1.on.aws/",
         "dlang": "https://e4rx7dem3yztmtx2cn3hj4qpwa0rssju.lambda-url.ap-northeast-1.on.aws/",
+        "d": "https://e4rx7dem3yztmtx2cn3hj4qpwa0rssju.lambda-url.ap-northeast-1.on.aws/",
         "hs": "https://4cbw4x3qgk2twmv337yp74mzve0howrg.lambda-url.ap-northeast-1.on.aws/",
         "php": "https://wysdglgjwakbg44hcibxdpmlda0xrdrm.lambda-url.ap-northeast-1.on.aws/",
         "cs": "https://zpijfsqi3zpmv6cjytgslmsala0rlbnm.lambda-url.ap-northeast-1.on.aws/",
@@ -30,6 +36,8 @@
         "go_test.go": "https://hgqaejogiftj2ait2oyiest3240gkkwa.lambda-url.ap-northeast-1.on.aws/",
         "rust": "https://sztj2p6h63v3hudnmisgeejakq0zmeda.lambda-url.ap-northeast-1.on.aws/",
         "rs": "https://sztj2p6h63v3hudnmisgeejakq0zmeda.lambda-url.ap-northeast-1.on.aws/",
-        "javascript": "https://sehpvhtkbnle3j2uvbihysikr40mbpkl.lambda-url.ap-northeast-1.on.aws/"
+        "javascript": "https://sehpvhtkbnle3j2uvbihysikr40mbpkl.lambda-url.ap-northeast-1.on.aws/",
+        "js": "https://sehpvhtkbnle3j2uvbihysikr40mbpkl.lambda-url.ap-northeast-1.on.aws/"
+        
     }
 }

--- a/completion_eval_analysis/send_query_to_multipl_eval_server.py
+++ b/completion_eval_analysis/send_query_to_multipl_eval_server.py
@@ -34,6 +34,42 @@ class SendQueryToMultiEvalServer():
             self.lang2url = json.load(f)["urls"]
         self.log.debug(f"set lang2url using: {url_json_path}")
 
+    def check_eval_server_health(self, first_json_path, try_num=5):
+        """Check the health of the evaluation server.
+        NOTE: awsサーバは初回アクセス時に起動していない場合があるため，サーバ起動確認を行う．
+        """
+        SLEEP_TIME = 10
+        self.log.debug(f"Checking server health using: {first_json_path}")
+        with open_json(first_json_path, "r") as f:
+            data = json.load(f)
+            query_lang = data.get("language", None)
+        if query_lang is None:
+            self.log.error(f"Error: No language found in JSON: {first_json_path}")
+            return False
+
+        base_url = self.lang2url.get(query_lang, None)
+        if base_url is None:
+            self.log.error(f"Error: No server URL for language: {query_lang}")
+            return False
+
+        health_url = f"{base_url}/healthz"
+        for i in range(try_num):
+            print(f"Health check attempt {i+1}/{try_num} for {health_url}")
+            try:
+                res = requests.get(url=health_url, timeout=5)
+                if res.status_code == requests.codes.ok:
+                    self.log.info(f"Server is healthy: {health_url}")
+                    return True
+                else:
+                    self.log.warning(f"Server health check failed: {health_url}, status: {res.status_code}")
+            except requests.RequestException as e:
+                self.log.error(f"Error checking server health: {e}")
+            print(f"Retrying in {SLEEP_TIME} seconds...")
+            time.sleep(SLEEP_TIME)
+
+        self.log.error(f"Server health check failed after {try_num} attempts.")
+        return False
+
     def send_query(self, query_d:dict):
         """
         Args:
@@ -91,7 +127,7 @@ class SendQueryToMultiEvalServer():
         # --------------------------- Request Sucess
         try:
             res = requests.post(url=_url, headers=headers, data=json.dumps(query_d), timeout=610)   # NOTE: timeout >= N completion * 1 timeout of evaluating completion
-            self.log.debug(f"res:{res}")
+            self.log.debug(f"language: {language}, res:{res}")
 
             # Case: Success
             if res.status_code == requests.codes.ok:
@@ -156,6 +192,7 @@ class SendQueryToMultiEvalServer():
 
     def process_dir(self, input_dir:str, output_dir:str, num_workers=1):
         """input_dir に含まれるcompletionコードを持つjson/json.gzを使用し，multipl-e 評価サーバに投げ，結果を output_dir に保存する．
+        serverにhealth問い合わせを行い，serverを起動状態を確認する. serverのhealth確認に使用するURLはinput_dirに先頭のjson/json.gzを利用するため, input_dirは単一の言語を想定.
         """
 
         # -----------------------------------------------------------------------------------------------------------
@@ -168,6 +205,13 @@ class SendQueryToMultiEvalServer():
         json_paths = list(Path(input_dir).glob("*.json")) + list(Path(input_dir).glob("*.json.gz"))  # list[Path]
         print(f"start evaluation (query to Multipl-E server). process_dir: {input_dir}, num: {len(json_paths)}")
 
+        # Eval Server Health check using first json file.
+        is_eval_server_alive = self.check_eval_server_health(json_paths[0], try_num=5)
+        if is_eval_server_alive is False:
+            print(f"[Error] Evaluation server seems down. Please check the server status. input_dir: {input_dir}")
+            return -1
+
+        # Process JSON files
         with ProcessPoolExecutor(max_workers=num_workers) as executor:
             futures = executor.map(self.process_json, [(json_file, output_dir) for json_file in json_paths])
             for _ in futures:
@@ -238,6 +282,7 @@ def test():
     print(f"query_result keys: {list(query_result.keys())}")
 
 if __name__ == "__main__":
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG) # temporary setting
     get_eval_results()
 
     # test()  # debug


### PR DESCRIPTION
MultiPL-Eにより生成コード評価を実行時，評価のリクエストを送る前にawsの該当言語サーバが生きているかの確認を行い，生きていればリクエストを送る仕様に変更．
AWSサーバはしばらくサーバにリクエストしないと止まってしまうため，サーバ生存確認リクエストを送ることでサーバが正常起動する挙動を利用している．

また，新たな言語表記に対応するURLリストの追加も行った．